### PR TITLE
Redirect stdout from pushd to /dev/null

### DIFF
--- a/pretty_logwarn
+++ b/pretty_logwarn
@@ -6,7 +6,8 @@ SENDER="openqa-monitor@$HOST"
 REPORTTO="${REPORTTO:-"nsinger@suse.de"}"
 
 # automatically update the script while preserving maybe added hotfixes
-pushd $(dirname $0)
+
+pushd $(dirname $0) > /dev/null
 # git pull --quiet --rebase origin master # This sometimes fails with "cannot rebase onto multiple branches".
 git fetch --quiet --all --prune
 git rebase --quiet origin/master


### PR DESCRIPTION
"pushd" always prints its new stack after a successfull call to stdout.
Since we only want to receive warn mails (which get generated by crond
if the script writes to stdout/stderr) in case of an error inside the
script we have to pipe stdout from pushd to /dev/null. In case of an
failure, pushd will use stderr and therefore can still provide us with
warnings if anything wents wrong (e.g. folder does not exist).