### PR TITLE
Ignore stopping worker immediately warning

### DIFF
--- a/in.log
+++ b/in.log
@@ -50,3 +50,4 @@ more output that is not properly prefixed
 [Tue Jun 13 10:04:30 2017] [websockets:warn] dead job 997744 aborted as incomplete
 [Fri Jul  7 04:50:50 2017] [10709:error] Failed to login: OpenID provider returned invalid data. Please retry again
 [Wed Aug  9 09:31:41 2017] [websockets:warn] A message received from unknown worker connection
+[Wed Aug  2 13:49:10 2017] [28861:warn] Stopping worker 4210 immediately

--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -51,4 +51,6 @@ $logwarn ${options} -m '\[.*:(debug|info|warn|error)\]' -p ${file} \
     '!error\] Failed to login: OpenID provider returned invalid data\. Please retry again' \
     `# https://progress.opensuse.org/issues/21836` \
     '!websockets:warn\] A message received from unknown worker connection' \
+    `# https://progress.opensuse.org/issues/21018` \
+    '!warn\] Stopping worker .* immediately' \
     '\[.*:(warn|error)\]' '!\[.*:(debug|info)\]' $@

--- a/test_logwarn
+++ b/test_logwarn
@@ -41,4 +41,5 @@ echo $out | grep -q '\[websockets:error] Unknown property received from worker 5
 echo $out | grep -q '\[websockets:warn] dead job 997744 aborted as incomplete' && exit 2
 echo $out | grep -q '\[10709:error\] Failed to login: OpenID provider returned invalid data\. Please retry again' && exit 2
 echo $out | grep -q '\[websockets:warn\] A message received from unknown worker connection' && exit 2
+echo $out | grep -q '\[28861:warn] Stopping worker 4210 immediately' && exit 2
 echo "PASSED"


### PR DESCRIPTION
Already did this here:
https://github.com/okurz/openqa_monitoring/commit/c347d0def20618dae68dc3d798d5469146218979

But since i missed the move to the new repo, i thought it might be good to just open a pull request again here.