### PR TITLE
Fix regexes for JobLocks ignore

### DIFF
--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -46,7 +46,7 @@ $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     `# https://progress.opensuse.org/issues/21018` \
     '!warn\] Stopping worker .* immediately' \
     `# https://progress.opensuse.org/issues/106613` \
-    '!error\].* DBIx::Class::Row::update(): Can.t update OpenQA::Schema::Result::JobLocks=.* row not found' \
+    '!error\].* DBIx::Class::Row::update\(\): Can.t update OpenQA::Schema::Result::JobLocks=.* row not found' \
     `# https://progress.opensuse.org/issues/23536` \
     '!error\] org.freedesktop.DBus.Error.NoReply: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.' \
     `# https://progress.opensuse.org/issues/19674 ` \

--- a/test_logwarn
+++ b/test_logwarn
@@ -91,7 +91,7 @@ is-ignored '\[error\] DBIx.*number of parameters must be between.*OpenQA/WebAPI/
 is-ignored '\[error\] mkdir /var/lib/openqa/images/0bf/862/.thumbs: File exists at /usr/share/openqa/script/../lib/OpenQA/Schema/Result/Jobs.pm line 1227'
 is-ignored '\[warn\].*Ignoring invalid group {"name":".*"}'
 is-ignored '\[error\] Template was modified'
-is-ignored '\[error\].* DBIx::Class::Row::update\(\): Can.t update OpenQA::Schema::Result::JobLocks'
+is-ignored '\[error\].* DBIx::Class::Row::update(): Can.t update OpenQA::Schema::Result::JobLocks'
 is-ignored '\[error\].* Cannot read symbolic link .*/.run_last): No such file or directory'
 is-ignored '\[error\].* Needle file .*.json not found within /var/lib/openqa/share/tests/opensuse/products/opensuse/needles.'
 is-ignored '\[error\].* Publishing opensuse.openqa.job.restart failed: Connect timeout (9 attempts left)'


### PR DESCRIPTION
logwarn needs escaped parens, grep needs no escaped parens