### PR TITLE
Exclude 'cmd returned 32768'

### DIFF
--- a/in.log
+++ b/in.log
@@ -83,3 +83,4 @@ more output that is not properly prefixed
 [2022-02-08T08:53:07.105395Z] [warn] [pid:16745] fatal: Invalid revision range cc2f36979a48111386b4a94cc7a5cbe0ba1aeaf8..97454f5f4aa4291da679136b2b987624acd85adc
 [2022-02-08T10:07:19.361122Z] [error] Testsuite 'autofs_client' is invalid
 [2022-02-01T00:18:19.109868Z] [warn] [pid:6059] 
+[2022-02-14T09:26:31.328344Z] [error] [pid:23389] cmd returned 32768

--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -86,4 +86,6 @@ $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     '!\[error\] Testsuite ''.*'' is invalid' \
     `# https://progress.opensuse.org/issues/105930` \
     '!\[warn\] \[pid:[0-9]*\] $' \
+    `# https://progress.opensuse.org/issues/106756` \
+    '!\[error\].*cmd returned 32768$' \
     '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' $@

--- a/test_logwarn
+++ b/test_logwarn
@@ -99,6 +99,7 @@ is-ignored '\[warn\].* Unable to wakeup scheduler: Request timeout'
 is-ignored '\[warn\].* fatal: Invalid revision range .*\.\.'
 is-ignored '\[error\] Testsuite .* is invalid'
 is-ignored '\[warn\] \[pid:[0-9]*\] $'
+is-ignored '\[error\].*cmd returned 32768$'
 
 done-testing
 


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/106756