### PR TITLE
Make ignore for `cmd returned …` more generic

### DIFF
--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -83,7 +83,7 @@ $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     `# https://progress.opensuse.org/issues/105930` \
     '!\[warn\] \[pid:[0-9]*\] $' \
     `# https://progress.opensuse.org/issues/106756` \
-    '!\[error\].*cmd returned 32768$' \
+    '!\[error\].*cmd returned [0-9]*$' \
     `# https://progress.opensuse.org/issues/106759` \
     '!\[error\] Worker [0-9]* has no heartbeat .[0-9]* seconds., restarting' \
     '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' $@


### PR DESCRIPTION
We've got `cmd returned 31744` yesterday so I don't think the return code
will always be the same number.

Related ticket: https://progress.opensuse.org/issues/106756