### PR TITLE
Revert "Add test for `Could not render a response at …`"

### DIFF
--- a/in.log
+++ b/in.log
@@ -83,4 +83,3 @@ more output that is not properly prefixed
 [2022-02-01T00:18:19.109868Z] [warn] [pid:6059] 
 [2022-02-14T09:26:31.328344Z] [error] [pid:23389] cmd returned 32768
 [2022-02-12T04:12:56.228360Z] [error] Worker 12345 has no heartbeat (400 seconds), restarting
-[2022-03-01T10:43:28.090838Z] [error] [j0WyMARuTaBr] Could not render a response at /usr/share/openqa/script/../lib/OpenQA/WebAPI.pm line 170.

--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -86,6 +86,4 @@ $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     '!\[error\].*cmd returned [0-9]*$' \
     `# https://progress.opensuse.org/issues/106759` \
     '!\[error\] Worker [0-9]* has no heartbeat .[0-9]* seconds., restarting' \
-    `# https://progress.opensuse.org/issues/107719` \
-    '!\[error\] Could not render a response at' \
     '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' $@

--- a/test_logwarn
+++ b/test_logwarn
@@ -99,7 +99,6 @@ is-ignored '\[warn\].* fatal: Invalid revision range .*\.\.'
 is-ignored '\[warn\] \[pid:[0-9]*\] $'
 is-ignored '\[error\].*cmd returned 32768$'
 is-ignored '\[error\] Worker [0-9]* has no heartbeat .[0-9]* seconds., restarting'
-is-ignored '\[error\] Could not render a response at'
 done-testing
 
 # explicitly exit with $rc unless we are run by prove


### PR DESCRIPTION
This reverts commit 8571e2e504c79e55981df989c868ac25f12e40ff.
and 300219670fa0a68c8583e4befa5331c80b450ee8 as they the issue
has been fixed by https://github.com/os-autoinst/openQA/pull/4539.