### PR TITLE
Revert "Remove "heartbeat" ignore which we would like to see again"

### DIFF
--- a/in.log
+++ b/in.log
@@ -82,4 +82,5 @@ more output that is not properly prefixed
 [2022-02-08T08:53:07.105395Z] [warn] [pid:16745] fatal: Invalid revision range cc2f36979a48111386b4a94cc7a5cbe0ba1aeaf8..97454f5f4aa4291da679136b2b987624acd85adc
 [2022-02-01T00:18:19.109868Z] [warn] [pid:6059] 
 [2022-02-14T09:26:31.328344Z] [error] [pid:23389] cmd returned 32768
+[2022-02-12T04:12:56.228360Z] [error] Worker 12345 has no heartbeat (400 seconds), restarting
 [2022-04-25T13:52:16.813172Z] [warn] [pid:25816] /var/lib/openqa/share/tests/obs/needles is not a git directory

--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -84,6 +84,8 @@ $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     '!\[warn\] \[pid:[0-9]*\] $' \
     `# https://progress.opensuse.org/issues/106756` \
     '!\[error\].*cmd returned [0-9]*$' \
+    `# https://progress.opensuse.org/issues/106759` \
+    '!\[error\] Worker [0-9]* has no heartbeat .[0-9]* seconds., restarting' \
     `# https://progress.opensuse.org/issues/110260` \
     '!\[warn\] .* is not a git directory' \
     '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' $@

--- a/test_logwarn
+++ b/test_logwarn
@@ -98,6 +98,7 @@ is-ignored '\[warn\].* Unable to wakeup scheduler: Request timeout'
 is-ignored '\[warn\].* fatal: Invalid revision range .*\.\.'
 is-ignored '\[warn\] \[pid:[0-9]*\] $'
 is-ignored '\[error\].*cmd returned 32768$'
+is-ignored '\[error\] Worker [0-9]* has no heartbeat .[0-9]* seconds., restarting'
 is-ignored '\[warn\] .* is not a git directory'
 done-testing
 


### PR DESCRIPTION
Reverts os-autoinst/openqa-logwarn#34 as we again see the message, see reopened https://progress.opensuse.org/issues/106759