### PR TITLE
Allow setting custom sender address

### DIFF
--- a/pretty_logwarn
+++ b/pretty_logwarn
@@ -3,7 +3,7 @@ set -o pipefail
 
 HOST=$(hostname --long)
 SUBJECT="OpenQA logreport for $HOST"
-SENDER="openqa-monitor@$HOST"
+SENDER="${SENDER:-"openqa-monitor@$HOST"}"
 REPORTTO="${REPORTTO:-"nsinger@suse.de"}"
 COLUMN_LIMIT="${COLUMN_LIMIT:-1000}"
 LINE_LIMIT="${LINE_LIMIT:-1000}"


### PR DESCRIPTION
Allow overriding the default sender address in case a valid e-mail is required.

Reference: https://progress.opensuse.org/issues/112673