### PR TITLE
Ignore OpenID-error "naive_verify_failed_return"

### DIFF
--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -82,4 +82,6 @@ $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     '!\[warn\] \[pid:[0-9]*\] $' \
     `# https://progress.opensuse.org/issues/106756` \
     '!\[error\].*cmd returned [0-9]*$' \
+    `# https://progress.opensuse.org/issues/125459` \
+    '!\[error\].*naive_verify_failed_return' \
     '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' $@


### PR DESCRIPTION
This problem is not actionable as it is most likely a temporary problem on the remote side.

Related ticket: https://progress.opensuse.org/issues/125459