### PR TITLE
Use logwarn from openSUSE in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,15 +11,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    container:
+      image: registry.opensuse.org/home/okurz/container/containers/tumbleweed:logwarn
     steps:
       - uses: actions/checkout@v2
 
-      - run: |
-          wget https://github.com/archiecobbs/logwarn/archive/refs/tags/1.0.16.tar.gz
-          tar xf 1.0.16.tar.gz
-          cd logwarn-1.0.16
-          ./autogen.sh && ./configure --prefix=/tmp/logwarn && make && make install
-
-      - run: |
-          PATH=/tmp/logwarn/bin:$PATH prove -v ./test_logwarn
+      - name: Run unit tests
+        run: ./test_logwarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: required
-before_script:
- - wget https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/logwarn/logwarn-1.0.11.tar.gz
- - tar -xzvf logwarn-1.0.11.tar.gz
- - pushd logwarn-1.0.11 && ./configure --prefix=/usr && make && sudo make install && popd
-script: ./test_logwarn
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A logwarn wrapper with openQA log specific rules.
 
 ## Usage
 
-* Install logwarn and call `logwarn_openqa`. By default it will read logs from
+* Install logwarn via `sudo zypper in logwarn` if you're on openSUSE
+  Tumbleweed or from https://github.com/archiecobbs/logwarn otherwise.
+* Call `logwarn_openqa`. By default it will read logs from
   /var/log/openqa which is where openQA stores logs by default. You can pass
   another path as the first argument.
 

--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 file="${file:-"${1:-"/var/log/openqa"}"}"
 options="${options:-""}"
-logwarn="${logwarn:-$(which logwarn)}"
+logwarn="${logwarn:-$(command -v logwarn)}"
 $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     `# ignore known warnings mentioned in https://progress.opensuse.org/issues/13952` \
     '!got a status update but has no worker' \


### PR DESCRIPTION
That's 1.0.17 at the time of this writing.

See: https://progress.opensuse.org/issues/128591