### PR TITLE
Avoid raising alerts about "Worker has no heartbeat" log messages

### DIFF
--- a/in.log
+++ b/in.log
@@ -80,3 +80,4 @@ more output that is not properly prefixed
 [2022-02-08T08:53:07.105395Z] [warn] [pid:16745] fatal: Invalid revision range cc2f36979a48111386b4a94cc7a5cbe0ba1aeaf8..97454f5f4aa4291da679136b2b987624acd85adc
 [2022-02-01T00:18:19.109868Z] [warn] [pid:6059] 
 [2022-02-14T09:26:31.328344Z] [error] [pid:23389] cmd returned 32768
+[2023-10-25T12:14:44.745934Z] [error] Worker 17519 has no heartbeat (900 seconds), restarting (see FAQ for more)

--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -84,4 +84,6 @@ $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     '!\[error\].*cmd returned [0-9]*$' \
     `# https://progress.opensuse.org/issues/125459` \
     '!\[error\].*naive_verify_failed_return' \
-    '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' $@
+    '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' \
+    `# https://progress.opensuse.org/issues/138536` \
+    '!\[error\].*Worker [0-9]+ has no heartbeat.*' $@

--- a/test_logwarn
+++ b/test_logwarn
@@ -97,6 +97,7 @@ is-ignored '\[warn\].* Unable to wakeup scheduler: Request timeout'
 is-ignored '\[warn\].* fatal: Invalid revision range .*\.\.'
 is-ignored '\[warn\] \[pid:[0-9]*\] $'
 is-ignored '\[error\].*cmd returned 32768$'
+is-ignored '\[error\] Worker 17519 has no heartbeat \(900 seconds\), restarting \(see FAQ for more\)'
 done-testing
 
 # explicitly exit with $rc unless we are run by prove


### PR DESCRIPTION
There's usually no severe problem, see
https://progress.opensuse.org/issues/138536.