### PR TITLE
Fix order of commands

### DIFF
--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -84,6 +84,7 @@ $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     '!\[error\].*cmd returned [0-9]*$' \
     `# https://progress.opensuse.org/issues/125459` \
     '!\[error\].*naive_verify_failed_return' \
-    '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' \
     `# https://progress.opensuse.org/issues/138536` \
-    '!\[error\].*Worker [0-9]+ has no heartbeat.*' $@
+    '!\[error\].*Worker [0-9]+ has no heartbeat.*' \
+    `# this line needs to be the last` \
+    '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' \ $@

--- a/test_logwarn
+++ b/test_logwarn
@@ -97,7 +97,7 @@ is-ignored '\[warn\].* Unable to wakeup scheduler: Request timeout'
 is-ignored '\[warn\].* fatal: Invalid revision range .*\.\.'
 is-ignored '\[warn\] \[pid:[0-9]*\] $'
 is-ignored '\[error\].*cmd returned 32768$'
-is-ignored '\[error\] Worker 17519 has no heartbeat \(900 seconds\), restarting \(see FAQ for more\)'
+is-ignored '\[error\] Worker 17519 has no heartbeat'
 done-testing
 
 # explicitly exit with $rc unless we are run by prove


### PR DESCRIPTION
See https://github.com/os-autoinst/openqa-logwarn/pull/49

The regex to include actually needs to be the last argument.

And the regex in the test wasn't really matching because the escaping of
`\(` is probably wrong, so I reduced that, as in the test we only need to match
for the unique thing in our example log. That's why the test was passing.

Issue: https://progress.opensuse.org/issues/165033