### PR TITLE
Ignore `Transaction already destroyed` errors

### DIFF
--- a/in.log
+++ b/in.log
@@ -80,3 +80,4 @@ more output that is not properly prefixed
 [2022-02-01T00:18:19.109868Z] [warn] [pid:6059] 
 [2022-02-14T09:26:31.328344Z] [error] [pid:23389] cmd returned 32768
 [2023-10-25T12:14:44.745934Z] [error] Worker 17519 has no heartbeat (900 seconds), restarting (see FAQ for more)
+[2025-06-19T14:33:06.404770Z] [error] Transaction already destroyed at /usr/lib/perl5/vendor_perl/5.26.1/Mojolicious/Renderer.pm line 31.

--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -84,5 +84,7 @@ $logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
     '!\[error\].*naive_verify_failed_return' \
     `# https://progress.opensuse.org/issues/138536` \
     '!\[error\].*Worker [0-9]+ has no heartbeat.*' \
+    `# https://progress.opensuse.org/issues/184486` \
+    '!.*Transaction already destroyed.*' \
     `# this line needs to be the last` \
     '\[.*:?(warn|error)\]' '!\[.*:?(debug|info)\]' \ $@

--- a/test_logwarn
+++ b/test_logwarn
@@ -104,6 +104,7 @@ is-ignored '\[warn\].* fatal: Invalid revision range .*\.\.'
 is-ignored '\[warn\] \[pid:[0-9]*\] $'
 is-ignored '\[error\].*cmd returned 32768$'
 is-ignored '\[error\] Worker 17519 has no heartbeat'
+is-ignored '\[error\] Transaction already destroyed at'
 done-testing
 
 # explicitly exit with $rc unless we are run by prove


### PR DESCRIPTION
Considering we already ignore `Worker … has no heartbreat` error we should also ignore `Transaction already destroyed` considering the latter is even more harmless and doesn't even necessarily mean our code is stuck/slow (as maybe the client has just closed the connection very soon).

I see no way of ignoring these errors in openQA code, hence ignoring them only here.

See https://progress.opensuse.org/issues/184486#note-4 for further explanation.