### PR TITLE
Support additional arguments in logwarn

### DIFF
--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -1,8 +1,10 @@
 #!/bin/sh -e
 file="${file:-"${1:-"/var/log/openqa"}"}"
 options="${options:-""}"
+# Mainly for [-T num/secs]. If it is set it applies to all subsequent patterns
+extra_options="${extra_options:-""}"
 logwarn="${logwarn:-$(command -v logwarn)}"
-$logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} \
+$logwarn ${options} -m '\[.*:?(debug|info|warn|error)\]' -p ${file} ${extra_options} \
     `# ignore known warnings mentioned in https://progress.opensuse.org/issues/13952` \
     '!got a status update but has no worker' \
     '!got an artefact but has no worker' \


### PR DESCRIPTION
As per the documentation there are options as `-T` which have to come after the filename. Here the script is modified to facilitate this extra options. Maybe this will need to be adjust also, in a way that applies to specific patterns in the future.As for not it applies to all subsequent patterns if it is set.