### PR TITLE
Ensure logwarn is not aborted

### DIFF
--- a/pretty_logwarn
+++ b/pretty_logwarn
@@ -19,8 +19,11 @@ git rebase --quiet origin/master
 # limit the length of each line to prevent overly long lines killing even
 # email clients, e.g. database exceptions list every single table index.
 # also truncate after too many lines
-WARNINGS=$(./logwarn_openqa "$1" | cut -c -$COLUMN_LIMIT | head -n $LINE_LIMIT || true)
+WARNINGS=$(./logwarn_openqa "$1" || true)
+OUTPUT=$(echo "$WARNINGS" | cut -c -$COLUMN_LIMIT | head -n $LINE_LIMIT || true)
+LINENUM=$(echo "$WARNINGS" | wc -l)
 
-if [ ! -z "$WARNINGS" ]; then
-    echo "$WARNINGS" | mail -r "$SENDER" -s "$SUBJECT" "$REPORTTO"
+if [ ! -z "$OUTPUT" ]; then
+    echo "Found $LINENUM lines"
+    echo "$OUTPUT" | mail -r "$SENDER" -s "$SUBJECT" "$REPORTTO"
 fi


### PR DESCRIPTION
If there are more than 1000 lines of matching output, `head` will end the pipe, and logwarn finishe without writing the status file, resulting in reading the same log lines in the next run.

Now the whole output is read first, and then the first 1000 printed.

Issue: https://progress.opensuse.org/issues/128591