### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: registry.opensuse.org/home/okurz/container/containers/tumbleweed:logwarn
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Run unit tests
         run: ./test_logwarn


### PR DESCRIPTION
This also fixes a warning about outdated nodejs