### PR TITLE
ci: restrict workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: registry.opensuse.org/home/okurz/container/containers/tumbleweed:logwarn

--- a/.github/workflows/commit_message_checker.yml
+++ b/.github/workflows/commit_message_checker.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   check-commit-message:
+    permissions:
+      contents: read
     secrets:
       accessToken: "${{ secrets.GITHUB_TOKEN }}"
     uses: os-autoinst/os-autoinst-common/.github/workflows/base-commit-message-checker.yml@master

--- a/.github/workflows/commit_message_checker.yml
+++ b/.github/workflows/commit_message_checker.yml
@@ -12,6 +12,4 @@ jobs:
   check-commit-message:
     permissions:
       contents: read
-    secrets:
-      accessToken: "${{ secrets.GITHUB_TOKEN }}"
     uses: os-autoinst/os-autoinst-common/.github/workflows/base-commit-message-checker.yml@master

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,14 @@
+[general]
+contrib=contrib-title-conventional-commits
+ignore=body-min-length,body-is-missing
+regex-style-search=True
+
+[ignore-body-lines]
+# Accept lines stating only a long unwrappable URL
+regex=^https?:\/\/\S+$
+
+[ignore-by-title]
+# "git subrepo" creates automatic, non-conventional commits we need to accept
+# https://progress.opensuse.org/issues/198254
+regex=^git subrepo pull
+ignore=all


### PR DESCRIPTION
Fixes:
* https://github.com/os-autoinst/openqa-logwarn/security/code-scanning/1
* https://github.com/os-autoinst/openqa-logwarn/security/code-scanning/2